### PR TITLE
fix(celery): Fix log permission errors for workers

### DIFF
--- a/docker/entrypoint_celery_beat.bash
+++ b/docker/entrypoint_celery_beat.bash
@@ -5,6 +5,9 @@ source /etc/profile
 # Run the main Celery worker (will not process `sync_kobocat_xforms` jobs).
 cd "${KPI_SRC_DIR}"
 
+# Ensure proper ownership of logs directory
+chown -R "${UWSGI_USER}:${UWSGI_GROUP}" "${KPI_LOGS_DIR}"
+
 exec celery -A kobo beat --loglevel=info \
     --logfile=${KPI_LOGS_DIR}/celery_beat.log \
     --pidfile=/tmp/celery_beat.pid \

--- a/docker/entrypoint_celery_kpi_worker.bash
+++ b/docker/entrypoint_celery_kpi_worker.bash
@@ -6,6 +6,9 @@ source /etc/profile
 
 cd "${KPI_SRC_DIR}"
 
+# Ensure proper ownership of logs directory
+chown -R "${UWSGI_USER}:${UWSGI_GROUP}" "${KPI_LOGS_DIR}"
+
 AUTOSCALE_MIN="${CELERY_AUTOSCALE_MIN:-2}"
 AUTOSCALE_MAX="${CELERY_AUTOSCALE_MAX:-6}"
 


### PR DESCRIPTION
Added a 'chown' command to the Celery worker entrypoint scripts to ensure the log directory is owned by the correct user before the worker process starts. This resolves the 'PermissionError: [Errno 13]'.
